### PR TITLE
Update cargo-casper to use casper-engine-test-support 2.0.2

### DIFF
--- a/resources/integration_tests.rs.in
+++ b/resources/integration_tests.rs.in
@@ -1,8 +1,17 @@
 #[cfg(test)]
 mod tests {
-    use casper_engine_test_support::{Code, Error, SessionBuilder, TestContextBuilder, Value};
+    use std::path::PathBuf;
+
+    use casper_engine_test_support::{
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, ARG_AMOUNT,
+        DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_GENESIS_CONFIG,
+        DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+    };
+    use casper_execution_engine::core::engine_state::{
+        run_genesis_request::RunGenesisRequest, GenesisAccount,
+    };
     use casper_types::{
-        account::AccountHash, runtime_args, PublicKey, RuntimeArgs, SecretKey, U512,
+        account::AccountHash, runtime_args, Key, Motes, PublicKey, RuntimeArgs, SecretKey, U512,
     };
 
     const MY_ACCOUNT: [u8; 32] = [7u8; 32];
@@ -14,54 +23,94 @@ mod tests {
 
     #[test]
     fn should_store_hello_world() {
+        // Create keypair.
         let secret_key = SecretKey::ed25519_from_bytes(MY_ACCOUNT).unwrap();
         let public_key = PublicKey::from(&secret_key);
+
+        // Create an AccountHash from a public key.
         let account_addr = AccountHash::from(&public_key);
+        // Create a GenesisAccount.
+        let account = GenesisAccount::account(
+            public_key,
+            Motes::new(U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE)),
+            None,
+        );
 
-        let mut context = TestContextBuilder::new()
-            .with_public_key(public_key, U512::from(500_000_000_000_000_000u64))
-            .build();
+        let mut genesis_config = DEFAULT_GENESIS_CONFIG.clone();
+        genesis_config.ee_config_mut().push_account(account);
 
+        let run_genesis_request = RunGenesisRequest::new(
+            *DEFAULT_GENESIS_CONFIG_HASH,
+            genesis_config.protocol_version(),
+            genesis_config.take_ee_config(),
+        );
         // The test framework checks for compiled Wasm files in '<current working dir>/wasm'.  Paths
         // relative to the current working dir (e.g. 'wasm/contract.wasm') can also be used, as can
         // absolute paths.
-        let session_code = Code::from(CONTRACT_WASM);
+        let session_code = PathBuf::from(CONTRACT_WASM);
         let session_args = runtime_args! {
             RUNTIME_ARG_NAME => VALUE,
         };
-        let session = SessionBuilder::new(session_code, session_args)
-            .with_address(account_addr)
+
+        let deploy_item = DeployItemBuilder::new()
+            .with_empty_payment_bytes(runtime_args! {
+                ARG_AMOUNT => *DEFAULT_PAYMENT
+            })
+            .with_session_code(session_code, session_args)
             .with_authorization_keys(&[account_addr])
+            .with_address(account_addr)
             .build();
 
-        let result_of_query: Result<Value, Error> =
-            context.run(session).query(account_addr, &[KEY.to_string()]);
+        let execute_request = ExecuteRequestBuilder::from_deploy_item(deploy_item).build();
 
-        let returned_value = result_of_query.expect("should be a value");
+        let mut builder = InMemoryWasmTestBuilder::default();
+        builder.run_genesis(&run_genesis_request).commit();
 
-        let expected_value = Value::from_t(VALUE.to_string()).expect("should construct Value");
-        assert_eq!(expected_value, returned_value);
+        // prepare assertions.
+        let result_of_query = builder.query(
+            None,
+            Key::Account(*DEFAULT_ACCOUNT_ADDR),
+            &[KEY.to_string()],
+        );
+        assert!(result_of_query.is_err());
+
+        // deploy the contract.
+        builder.exec(execute_request).commit().expect_success();
+
+        // make assertions
+        let result_of_query = builder
+            .query(None, Key::Account(account_addr), &[KEY.to_string()])
+            .expect("should be stored value.")
+            .as_cl_value()
+            .expect("should be cl value.")
+            .clone()
+            .into_t::<String>()
+            .expect("should be string.");
+
+        assert_eq!(result_of_query, VALUE);
     }
 
     #[test]
-    #[should_panic(expected = "ApiError::MissingArgument")]
     fn should_error_on_missing_runtime_arg() {
         let secret_key = SecretKey::ed25519_from_bytes(MY_ACCOUNT).unwrap();
         let public_key = PublicKey::from(&secret_key);
         let account_addr = AccountHash::from(&public_key);
 
-        let mut context = TestContextBuilder::new()
-            .with_public_key(public_key, U512::from(500_000_000_000_000_000u64))
-            .build();
-
-        let session_code = Code::from(CONTRACT_WASM);
+        let session_code = PathBuf::from(CONTRACT_WASM);
         let session_args = RuntimeArgs::new();
-        let session = SessionBuilder::new(session_code, session_args)
-            .with_address(account_addr)
+
+        let deploy_item = DeployItemBuilder::new()
+            .with_empty_payment_bytes(runtime_args! {ARG_AMOUNT => *DEFAULT_PAYMENT})
             .with_authorization_keys(&[account_addr])
+            .with_address(*DEFAULT_ACCOUNT_ADDR)
+            .with_session_code(session_code, session_args)
             .build();
 
-        context.run(session);
+        let execute_request = ExecuteRequestBuilder::from_deploy_item(deploy_item).build();
+
+        let mut builder = InMemoryWasmTestBuilder::default();
+        builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST).commit();
+        builder.exec(execute_request).commit().expect_failure();
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,9 +7,11 @@ use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
 
 pub static CL_CONTRACT: Lazy<Dependency> =
     Lazy::new(|| Dependency::new("casper-contract", "1.4.2"));
-pub static CL_TYPES: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-types", "1.4.2"));
+pub static CL_TYPES: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-types", "1.4.4"));
 pub static CL_ENGINE_TEST_SUPPORT: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-engine-test-support", "1.0.0"));
+    Lazy::new(|| Dependency::new("casper-engine-test-support", "2.0.2"));
+pub static CL_EXECUTION_ENGINE: Lazy<Dependency> =
+    Lazy::new(|| Dependency::new("casper-execution-engine", "1.4.2"));
 pub static PATCH_SECTION: Lazy<String> = Lazy::new(|| match ARGS.workspace_path() {
     Some(workspace_path) => {
         format!(

--- a/src/tests_package.rs
+++ b/src/tests_package.rs
@@ -6,7 +6,9 @@ use std::path::PathBuf;
 use once_cell::sync::Lazy;
 
 use crate::{
-    common::{self, CL_CONTRACT, CL_ENGINE_TEST_SUPPORT, CL_TYPES, PATCH_SECTION},
+    common::{
+        self, CL_CONTRACT, CL_ENGINE_TEST_SUPPORT, CL_EXECUTION_ENGINE, CL_TYPES, PATCH_SECTION,
+    },
     ARGS,
 };
 
@@ -19,10 +21,11 @@ static INTEGRATION_TESTS_RS: Lazy<PathBuf> =
 
 pub static TEST_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(
-        "{}{}{}",
+        "{}{}{}{}",
         CL_CONTRACT.display_with_features(false, vec!["test-support"]),
         CL_ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
-        CL_TYPES.display_with_features(true, vec![]),
+        CL_EXECUTION_ENGINE.display_with_features(true, vec![]),
+        CL_TYPES.display_with_features(true, vec![])
     )
 });
 


### PR DESCRIPTION
# About These Changes.

* Update dependencies to latest version.
* Update generated test to use types from the latest version of `casper-engine-test-support` (`2.0.2`).