### PR TITLE
ZH-SRE-I243: initial commit of ci and publish pipelines

### DIFF
--- a/.github/workflows/ci-cargo-casper.yml
+++ b/.github/workflows/ci-cargo-casper.yml
@@ -1,0 +1,48 @@
+---
+name: ci-cargo-casper
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build_and_test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+
+      - name: Fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+      - name: Audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: audit
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/publish-cargo-casper.yml
+++ b/.github/workflows/publish-cargo-casper.yml
@@ -1,0 +1,24 @@
+---
+name: publish-cargo-casper
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Crate Publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --token ${{ secrets.crates_io_token }}


### PR DESCRIPTION
Adds:
- `.github/workflows/ci-cargo-casper.yml`
    - runs on `pull-request` and `push` to `main` branch
    - ignores markdown file changes
- `.github/workflows/publish-cargo-casper.yml`
    - runs when a `release` is published
    - publishes crate to `crates.io`
    
Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/243