### PR TITLE
CI: use lock file in workflows

### DIFF
--- a/.github/workflows/ci-cargo-casper.yml
+++ b/.github/workflows/ci-cargo-casper.yml
@@ -34,21 +34,23 @@ jobs:
       - name: Fmt
         uses: actions-rs/cargo@v1
         with:
-          command: fmt
-          args: -- --check
+          command: --locked
+          args: fmt -- --check
 
       - name: Audit
         uses: actions-rs/cargo@v1
         with:
-          command: audit
+          command: --locked
+          args: audit
 
       - name: Clippy
         uses: actions-rs/cargo@v1
         with:
-          command: clippy
-          args: --all-targets
+          command: --locked
+          args: clippy --all-targets
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: --locked
+          args: test

--- a/.github/workflows/publish-cargo-casper.yml
+++ b/.github/workflows/publish-cargo-casper.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Crate Publish
         uses: actions-rs/cargo@v1
         with:
-          command: publish
-          args: --token ${{ secrets.crates_io_token }}
+          command: --locked
+          args: publish --token ${{ secrets.crates_io_token }}


### PR DESCRIPTION
Changes:
- Have cargo use `--locked`

Ticket:
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/247
