### PR TITLE
ZH-SRE-I249: Add nightly test workflow

### DIFF
--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -29,3 +29,11 @@ jobs:
         with:
           command: --locked
           args: test
+
+      - name: Slack Notification
+        uses: ravsamhq/notify-slack-action@v1
+        if: always()
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -1,0 +1,31 @@
+---
+name: nightly-scheduled-test
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # runs every day at midnight
+    - cron: "0 0 * * *"
+
+jobs:
+  nightly-cargo-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get nightly toolchain from file
+        id: nightly-toolchain
+        run: echo "::set-output name=version::$(cat resources/rust-toolchain.in)"
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ steps.nightly-toolchain.outputs.version }}
+          profile: minimal
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: --locked
+          args: test


### PR DESCRIPTION
Adds:
- nightly run of `cargo --locked test` scheduled for midnight.
- notifies status to slack channel
