### PR TITLE
Create git repository to more closely mimic cargo init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+### Changed
+* Now creates an empty git repository in the root of the generated project.
 
 
 ## [2.0.0] - 2021-11-30

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,13 @@
+use crate::{common, ARGS};
+
+pub fn init() {
+    let current_dir = std::env::current_dir().expect("should get current dir");
+    std::env::set_current_dir(ARGS.root_path()).expect("package directory should exist");
+    std::process::Command::new("git")
+        .arg("init")
+        .output()
+        .expect("should initialize git repository");
+    common::write_file(".gitignore", "target/");
+    std::env::set_current_dir(current_dir)
+        .expect("should be able to go back to previous directory");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 pub mod common;
 mod contract_package;
 pub mod dependency;
+mod git;
 mod makefile;
 mod rust_toolchain;
 mod tests_package;
@@ -157,4 +158,5 @@ fn main() {
     rust_toolchain::create();
     makefile::create();
     travis_yml::create();
+    git::init();
 }


### PR DESCRIPTION
I've updated this script to create a new git repository, in order to more closely mimic cargo init. The implementation goes to the root directory of the new project, uses std::process to run `git init`, and then returns to the original directory.
