### PR TITLE
Update casper dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,8 +77,8 @@ dependencies = [
  "colour",
  "once_cell",
  "reqwest",
+ "serde_json",
  "tempfile",
- "toml",
 ]
 
 [[package]]
@@ -1022,15 +1022,6 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ once_cell = "1"
 [dev-dependencies]
 assert_cmd = "2"
 reqwest = { version = "0.11.7", features = ["blocking"] }
+serde_json = "1"
 tempfile = "3"
-toml = "0.5.8"

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,12 +6,12 @@ use once_cell::sync::Lazy;
 use crate::{dependency::Dependency, CasperOverrides, ARGS, FAILURE_EXIT_CODE};
 
 pub static CL_CONTRACT: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-contract", "1.4.2"));
-pub static CL_TYPES: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-types", "1.4.4"));
+    Lazy::new(|| Dependency::new("casper-contract", "1.4.3"));
+pub static CL_TYPES: Lazy<Dependency> = Lazy::new(|| Dependency::new("casper-types", "1.4.5"));
 pub static CL_ENGINE_TEST_SUPPORT: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-engine-test-support", "2.0.2"));
+    Lazy::new(|| Dependency::new("casper-engine-test-support", "2.0.3"));
 pub static CL_EXECUTION_ENGINE: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-execution-engine", "1.4.2"));
+    Lazy::new(|| Dependency::new("casper-execution-engine", "1.4.3"));
 pub static PATCH_SECTION: Lazy<String> = Lazy::new(|| match ARGS.casper_overrides() {
     Some(CasperOverrides::WorkspacePath(path)) => {
         format!(
@@ -67,73 +67,78 @@ pub fn write_file<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) {
 #[cfg(test)]
 pub mod tests {
     use reqwest::blocking;
-    use toml::Value;
+    use serde_json::Value;
 
     use super::*;
 
-    const CL_CONTRACT_TOML_URL: &str =
-        "https://raw.githubusercontent.com/casper-network/casper-node/dev/smart_contracts/contract/Cargo.toml";
-    const CL_TYPES_TOML_URL: &str =
-        "https://raw.githubusercontent.com/casper-network/casper-node/dev/types/Cargo.toml";
-    const CL_ENGINE_TEST_SUPPORT_TOML_URL: &str =
-        "https://raw.githubusercontent.com/casper-network/casper-node/dev/execution_engine_testing/test_support/Cargo.toml";
-    const CL_EXECUTION_ENGINE_TOML_URL: &str =
-        "https://raw.githubusercontent.com/casper-network/casper-node/dev/execution_engine/Cargo.toml";
-    const PACKAGE_FIELD_NAME: &str = "package";
-    const VERSION_FIELD_NAME: &str = "version";
+    const CRATES_IO_RAW_INDEX_URL_FOR_CASPER_CRATES: &str =
+        "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/ca/sp/";
+    const CRATES_IO_INDEX_URL_FOR_CASPER_CRATES: &str =
+        "https://github.com/rust-lang/crates.io-index/blob/master/ca/sp/";
+    const VERSION_FIELD_NAME: &str = "vers";
 
     /// Checks the version of the package specified by the Cargo.toml at `toml_path` is equal to
     /// the hard-coded one specified in `dep.version()`.
-    pub fn check_package_version(dep: &Dependency, toml_url: &str) {
-        let toml_contents = blocking::get(toml_url)
+
+    /// https://crates.io/data-access
+    fn check_latest_published_casper_package_version(dep: &Dependency) {
+        let url = format!(
+            "{}{}",
+            CRATES_IO_RAW_INDEX_URL_FOR_CASPER_CRATES,
+            dep.name()
+        );
+        let crate_io_index_contents = blocking::get(url)
             .unwrap_or_else(|error| {
                 panic!(
-                    "should get Cargo.toml for {} from GitHub: {}",
+                    "should get index file for {} from GitHub: {}",
                     dep.name(),
                     error
                 )
             })
             .text()
             .unwrap_or_else(|error| {
-                panic!("should parse Cargo.toml for {}: {}", dep.name(), error)
+                panic!("should parse index file for {}: {}", dep.name(), error)
             });
 
-        let toml = toml_contents.parse::<Value>().unwrap();
+        let latest_entry: Value = serde_json::from_str(
+            crate_io_index_contents
+                .lines()
+                .last()
+                .expect("index file should contain at least one entry"),
+        )
+        .expect("latest entry from index file should parse as JSON");
+        let latest_publish_version = latest_entry[VERSION_FIELD_NAME].as_str().unwrap();
 
-        let expected_version = toml[PACKAGE_FIELD_NAME][VERSION_FIELD_NAME]
-            .as_str()
-            .unwrap();
         // If this fails, ensure `dep.version()` is updated to match the value in the Cargo.toml at
         // `toml_url`.
         assert_eq!(
-            expected_version,
+            latest_publish_version,
             dep.version(),
-            "\n\nEnsure local version of {:?} is updated to {} as defined in {}\n\n",
+            "\n\nEnsure local version of {:?} is updated to {} as defined in last version of {}{}\n\n",
             dep,
-            expected_version,
-            toml_url
+            latest_publish_version,
+            CRATES_IO_INDEX_URL_FOR_CASPER_CRATES,
+            dep.name()
         );
     }
 
     #[test]
     fn check_cl_contract_version() {
-        check_package_version(&*CL_CONTRACT, CL_CONTRACT_TOML_URL);
+        check_latest_published_casper_package_version(&*CL_CONTRACT);
     }
 
     #[test]
-    #[ignore]
     fn check_cl_types_version() {
-        check_package_version(&*CL_TYPES, CL_TYPES_TOML_URL);
+        check_latest_published_casper_package_version(&*CL_TYPES);
     }
 
     #[test]
-    #[ignore]
     fn check_cl_engine_test_support_version() {
-        check_package_version(&*CL_ENGINE_TEST_SUPPORT, CL_ENGINE_TEST_SUPPORT_TOML_URL);
+        check_latest_published_casper_package_version(&*CL_ENGINE_TEST_SUPPORT);
     }
 
     #[test]
     fn check_cl_execution_engine_version() {
-        check_package_version(&*CL_EXECUTION_ENGINE, CL_EXECUTION_ENGINE_TOML_URL);
+        check_latest_published_casper_package_version(&*CL_EXECUTION_ENGINE);
     }
 }

--- a/src/rust_toolchain.rs
+++ b/src/rust_toolchain.rs
@@ -23,8 +23,8 @@ mod tests {
             .text()
             .expect("should parse rust-toolchain");
 
-        // If this fails, ensure ../resources/rust-toolchain.in is updated to match the value in
-        // "casper-node/rust-toolchain".
+        // If this fails, ensure there's not a mismatch between ../resources/rust-toolchain.in and
+        // https://github.com/casper-network/casper-node/blob/dev/smart_contracts/rust-toolchain.
         assert_eq!(&*expected_toolchain_value, CONTENTS);
     }
 }


### PR DESCRIPTION
This updates the tool to use the latest published version of the casper crates in generated projects.

It also updates the tests to use crate versions as provided by crates.io, making the check for latest versions more robust.
