### PR TITLE
Update in preparation for dev branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.0"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
  "atty",
  "bitflags",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
  "bytes",
  "fnv",
@@ -344,9 +344,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.17"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itertools"
@@ -447,9 +447,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "lock_api"
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
@@ -502,14 +502,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi",
  "winapi",
 ]
 
@@ -524,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "09bf6f32a3afefd0b587ee42ed19acd945c6d1f3b5424040f50b2f24ab16be77"
 dependencies = [
  "lazy_static",
  "libc",
@@ -561,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "openssl"
@@ -694,18 +695,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
 dependencies = [
  "bitflags",
 ]
@@ -727,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
  "base64",
  "bytes",
@@ -885,9 +886,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -910,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -925,9 +926,9 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tinyvec"
@@ -953,7 +954,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.0",
+ "mio 0.8.2",
  "num_cpus",
  "pin-project-lite",
  "socket2",
@@ -992,9 +993,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1003,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
 ]
@@ -1073,6 +1074,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1183,9 +1190,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winreg"
-version = "0.7.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]

--- a/resources/integration_tests.rs.in
+++ b/resources/integration_tests.rs.in
@@ -4,8 +4,9 @@ mod tests {
 
     use casper_engine_test_support::{
         DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, ARG_AMOUNT,
-        DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_GENESIS_CONFIG,
-        DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_PAYMENT, DEFAULT_RUN_GENESIS_REQUEST,
+        DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_CHAINSPEC_REGISTRY,
+        DEFAULT_GENESIS_CONFIG, DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_PAYMENT,
+        DEFAULT_RUN_GENESIS_REQUEST,
     };
     use casper_execution_engine::core::engine_state::{
         run_genesis_request::RunGenesisRequest, GenesisAccount,
@@ -43,6 +44,7 @@ mod tests {
             *DEFAULT_GENESIS_CONFIG_HASH,
             genesis_config.protocol_version(),
             genesis_config.take_ee_config(),
+            DEFAULT_CHAINSPEC_REGISTRY.clone(),
         );
         // The test framework checks for compiled Wasm files in '<current working dir>/wasm'.  Paths
         // relative to the current working dir (e.g. 'wasm/contract.wasm') can also be used, as can

--- a/src/contract_package.rs
+++ b/src/contract_package.rs
@@ -12,7 +12,7 @@ use crate::{
 
 const PACKAGE_NAME: &str = "contract";
 static CONTRACT_PACKAGE_ROOT: Lazy<PathBuf> =
-    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME.replace("-", "_")));
+    Lazy::new(|| ARGS.root_path().join(PACKAGE_NAME.replace('-', "_")));
 static CARGO_TOML: Lazy<PathBuf> = Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("Cargo.toml"));
 static MAIN_RS: Lazy<PathBuf> = Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("src/main.rs"));
 static CONFIG_TOML: Lazy<PathBuf> = Lazy::new(|| CONTRACT_PACKAGE_ROOT.join(".cargo/config.toml"));
@@ -52,7 +52,7 @@ lto = true
 {}"#,
         PACKAGE_NAME,
         &*CONTRACT_DEPENDENCIES,
-        PACKAGE_NAME.replace("-", "_"),
+        PACKAGE_NAME.replace('-', "_"),
         &*PATCH_SECTION
     )
 });

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,3 +1,5 @@
+use crate::ARGS;
+
 /// Used to hold the information about the Casper dependencies which will be required by the
 /// generated Cargo.toml files.
 #[derive(Debug)]
@@ -15,11 +17,17 @@ impl Dependency {
     }
 
     pub fn display_with_features(&self, default_features: bool, features: Vec<&str>) -> String {
+        let version = if ARGS.casper_overrides().is_some() {
+            "*"
+        } else {
+            &self.version
+        };
+
         if default_features && features.is_empty() {
-            return format!("{} = \"{}\"\n", self.name, self.version);
+            return format!("{} = \"{}\"\n", self.name, version);
         }
 
-        let mut output = format!(r#"{} = {{ version = "{}""#, self.name, self.version);
+        let mut output = format!(r#"{} = {{ version = "{}""#, self.name, version);
 
         if !default_features {
             output = format!("{}, default-features = false", output);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,13 +1,13 @@
-use std::{fs, process::Output};
+use std::{env, fs, process::Output};
 
 use assert_cmd::Command;
 
 const FAILURE_EXIT_CODE: i32 = 101;
 const SUCCESS_EXIT_CODE: i32 = 0;
 const TEST_PATH: &str = "test";
-// TODO - uncomment
-// const GIT_URL_ARG: &str = "--git-url=https://github.com/casper-network/casper-node";
-// const GIT_BRANCH_ARG: &str = "--git-branch=dev";
+const GIT_URL_ARG: &str = "--git-url=https://github.com/casper-network/casper-node";
+const PR_TARGET_BRANCH_NAME_ENV_VAR: &str = "GITHUB_BASE_REF";
+const CI_BRANCH_NAME_ENV_VAR: &str = "GITHUB_REF_NAME";
 
 #[test]
 fn should_fail_when_target_path_already_exists() {
@@ -44,8 +44,7 @@ fn output_from_command(mut command: Command) -> Output {
     }
 }
 
-#[test]
-fn should_run_cargo_casper() {
+fn run_make_test_on_generated_project(maybe_git_branch_arg: Option<String>) {
     let temp_dir = tempfile::tempdir().unwrap().into_path();
 
     // Run 'cargo-casper <test dir>/<subdir>'
@@ -53,9 +52,11 @@ fn should_run_cargo_casper() {
     let test_dir = temp_dir.join(subdir);
     let mut tool_cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     tool_cmd.arg(&test_dir);
-    // TODO - uncomment
-    // tool_cmd.arg(GIT_URL_ARG);
-    // tool_cmd.arg(GIT_BRANCH_ARG);
+    if let Some(git_branch_arg) = maybe_git_branch_arg {
+        // Append '--git-url=...' and '--git-branch=...' args.
+        tool_cmd.arg(GIT_URL_ARG);
+        tool_cmd.arg(git_branch_arg);
+    }
 
     // The CI environment doesn't have a Git user configured, so we can set the env var `USER` for
     // use by 'cargo new' which is called as a subprocess of 'cargo-casper'.
@@ -84,4 +85,71 @@ fn should_run_cargo_casper() {
 
     // Cleans up temporary directory, but leaves it otherwise if the test failed.
     fs::remove_dir_all(&temp_dir).unwrap();
+}
+
+/// Checks that running `cargo-casper` with no specified overrides yields a generated project which
+/// passes `make test`.
+///
+/// The generated project will have manifests which use the latest crates.io versions of the Casper
+/// dependencies.
+///
+/// If `GITHUB_BASE_REF` or `GITHUB_REF_NAME` are set and specify `main`, the test is run.  If
+/// neither are set, the test is an auto-pass.
+#[test]
+fn should_run_cargo_casper_using_published_crates() {
+    match env::var(PR_TARGET_BRANCH_NAME_ENV_VAR).or_else(|_| env::var(CI_BRANCH_NAME_ENV_VAR)) {
+        Ok(branch_name) if branch_name == "main" => (),
+        Ok(branch_name) => {
+            println!(
+                "skipping 'should_run_cargo_casper_using_published_crates' as branch name '{}' is \
+                not 'main'",
+                branch_name
+            );
+            return;
+        }
+        Err(_) => {
+            println!(
+                "skipping 'should_run_cargo_casper_using_published_crates' as neither {} nor {} is \
+                set",
+                PR_TARGET_BRANCH_NAME_ENV_VAR, CI_BRANCH_NAME_ENV_VAR
+            );
+            return;
+        }
+    }
+
+    run_make_test_on_generated_project(None)
+}
+
+/// Checks that running `cargo-casper` with Git overrides yields a generated project which passes
+/// `make test`.
+///
+/// The generated project will have manifests which use Git overrides for the Casper dependencies.
+/// The versions will all be specified as `"*"` and the override branch of the `casper-node` repo
+/// will be as defined in the env var `GITHUB_BASE_REF` (for PRs) or `GITHUB_REF_NAME` (for other CI
+/// runs) which is set by GitHub actions.
+///
+/// If neither `GITHUB_BASE_REF` nor `GITHUB_REF_NAME` is set, the test is an auto-pass.
+#[test]
+fn should_run_cargo_casper_using_git_overrides() {
+    // TODO - remove the following block.
+    {
+        let pr_target_branch = env::var(PR_TARGET_BRANCH_NAME_ENV_VAR);
+        let ci_branch = env::var(CI_BRANCH_NAME_ENV_VAR);
+        println!("{}: {:?}", PR_TARGET_BRANCH_NAME_ENV_VAR, pr_target_branch);
+        println!("{}: {:?}", CI_BRANCH_NAME_ENV_VAR, ci_branch);
+    }
+
+    let git_branch_arg = if let Ok(branch_name) =
+        env::var(PR_TARGET_BRANCH_NAME_ENV_VAR).or_else(|_| env::var(CI_BRANCH_NAME_ENV_VAR))
+    {
+        format!("--git-branch={}", branch_name)
+    } else {
+        println!(
+            "skipping 'should_run_cargo_casper_using_git_overrides' as neither {} nor {} is set",
+            PR_TARGET_BRANCH_NAME_ENV_VAR, CI_BRANCH_NAME_ENV_VAR
+        );
+        return;
+    };
+
+    run_make_test_on_generated_project(Some(git_branch_arg))
 }


### PR DESCRIPTION
This PR updates the cargo-casper tool to be compatible with current changes in the `dev` branch of the `casper-node` repo.  It updates the test suite as follows:
* if a PR is made targeting the `main` branch, or CI is run on the `main` branch, `should_run_cargo_casper_using_published_crates` is run.  This test executes cargo-casper to generate a project which itself depends upon only the most recent published Casper crates, and runs `make test` in that generated project
* if a PR is made targeting branch `b`, or CI is run on branch `b`, `should_run_cargo_casper_using_git_overrides` is run.  This test is similar to the one above, except the generated project's manifests contain overrides for the Casper deps, specifying the GitHub URL of the `casper-node` crate and branch `b`, with versions set to `"*"`.

This allows for `main` being updated to keep the current published version of `cargo-casper` compatible with the latest published Casper dependencies, while allowing for feature branches (like `dev`) to be developed in parallel with their namesake feature branches in the `casper-node` repo.