### PR TITLE
NIGHTLY: use matrix branch for cron

### DIFF
--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Test
         uses: actions-rs/cargo@v1
+        env:
+          BRANCH_SELECTOR: ${{ matrix.branch }}
         with:
           command: --locked
           args: test


### PR DESCRIPTION
Set an Env var `BRANCH_SELECTOR` equal to the matrix branch. Used in the cron testing.
