### PR TITLE
Update toolchain unit test to only run on dev branch

### DIFF
--- a/src/rust_toolchain.rs
+++ b/src/rust_toolchain.rs
@@ -9,15 +9,46 @@ pub fn create() {
 
 #[cfg(test)]
 mod tests {
+    use std::env;
+
     use reqwest::blocking;
 
     use super::CONTENTS;
 
+    const TEST_BRANCH_NAME: &str = "dev";
+    const CRON_JOB_BRANCH_NAME_ENV_VAR: &str = "BRANCH_SELECTOR";
+    const PR_TARGET_BRANCH_NAME_ENV_VAR: &str = "GITHUB_BASE_REF";
+    const CI_BRANCH_NAME_ENV_VAR: &str = "GITHUB_REF_NAME";
     const CASPER_NODE_TOOLCHAIN_URL: &str =
         "https://raw.githubusercontent.com/casper-network/casper-node/dev/smart_contracts/rust-toolchain";
 
+    /// Checks that the pinned version of Rust is that of the `dev` branch of casper-node.
+    ///
+    /// If none of `BRANCH_SELECTOR`, `GITHUB_BASE_REF` and `GITHUB_REF_NAME` are set, or they're
+    /// all set to empty strings, the test is an auto-pass.
+    ///
+    /// For testing locally, you can manually run e.g.
+    /// ```
+    /// BRANCH_SELECTOR=dev cargo t
+    /// ```
     #[test]
-    fn check_toolchain_version() {
+    fn check_toolchain_version_on_dev() {
+        if let Ok(true) = env::var(CRON_JOB_BRANCH_NAME_ENV_VAR)
+            .or_else(|_| env::var(PR_TARGET_BRANCH_NAME_ENV_VAR))
+            .or_else(|_| env::var(CI_BRANCH_NAME_ENV_VAR))
+            .map(|env_var| env_var == TEST_BRANCH_NAME)
+        {
+        } else {
+            println!(
+                "skipping 'check_toolchain_version_on_dev' as none of {}, {} and {} are set to {}",
+                CRON_JOB_BRANCH_NAME_ENV_VAR,
+                PR_TARGET_BRANCH_NAME_ENV_VAR,
+                CI_BRANCH_NAME_ENV_VAR,
+                TEST_BRANCH_NAME,
+            );
+            return;
+        }
+
         let expected_toolchain_value = blocking::get(CASPER_NODE_TOOLCHAIN_URL)
             .expect("should get rust-toolchain from GitHub")
             .text()


### PR DESCRIPTION
Backport of #36 to `dev` branch.