### PR TITLE
CI: use specifc commit for keepalive

### DIFF
--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -62,4 +62,4 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Fake Commit after 50 days
-        uses: gautamkrishnar/keepalive-workflow@v1  # default of 50 days
+        uses: gautamkrishnar/keepalive-workflow@790c7f09285a59b09bb578c85e271c6ff2af97c4 #v1.1.0


### PR DESCRIPTION
Changes:
- best practice is to use a specific commit
