### PR TITLE
Rustc wrapper for cross-platform reproducibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 
+## [2.2.1] - 2024-06-21
+
+### Added
+* `--wrapper` option for using `rustc` wrapper to build reproducible wasm.
+
+
 
 ## [2.2.0] - 2024-02-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,16 +19,16 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -58,19 +58,19 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467"
+checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
 dependencies = [
  "anstyle",
  "bstr",
@@ -80,6 +80,12 @@ dependencies = [
  "predicates-tree",
  "wait-timeout",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -104,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -145,7 +151,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cargo-casper"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -173,45 +179,31 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.24"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb690e81c7840c0d7aade59f242ea3b41b9bc27bcd5997890e7702ae4b32e487"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
- "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.24"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed2e96bc16d8d740f6f48d663eddf4b8a0983e79210fd55479b7bcd0a69860e"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "once_cell",
  "strsim",
  "terminal_size",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
@@ -221,11 +213,11 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colour"
-version = "0.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58a501d883cdb7f1a780407eefba005458b8fdf7c09213ea0104879bf87aa9"
+checksum = "b536eebcabe54980476d120a182f7da2268fe02d22575cca99cee5fdda178280"
 dependencies = [
- "crossterm",
+ "winapi",
 ]
 
 [[package]]
@@ -243,31 +235,6 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "crossterm"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "difflib"
@@ -349,6 +316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -383,11 +351,23 @@ checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -398,15 +378,15 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http",
  "indexmap",
  "slab",
@@ -422,22 +402,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
-
-[[package]]
 name = "http"
-version = "0.2.11"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -446,12 +414,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -462,46 +442,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
-version = "0.14.28"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -525,32 +535,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.10"
+name = "is_terminal_polyfill"
+version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
-dependencies = [
- "hermit-abi",
- "rustix 0.38.31",
- "windows-sys 0.52.0",
-]
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itoa"
@@ -581,25 +575,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -635,7 +613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.48.0",
 ]
@@ -656,16 +633,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -728,33 +695,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.48.5",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -820,15 +784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,20 +791,24 @@ checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
  "http",
  "http-body",
+ "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -875,24 +834,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "rustix"
@@ -903,17 +863,48 @@ dependencies = [
  "bitflags 2.4.2",
  "errno",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
  "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -930,12 +921,6 @@ checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1004,36 +989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,10 +1014,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
+name = "spin"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "syn"
@@ -1077,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "system-configuration"
@@ -1110,17 +1077,17 @@ checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "rustix 0.38.31",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "terminal_size"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.37.27",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -1155,7 +1122,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.48.0",
@@ -1172,6 +1138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1161,27 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -1236,6 +1234,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1516,10 +1520,16 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-casper"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2021"
 description = "A command line tool for creating a Wasm smart contract and tests for use on the Casper network."
@@ -12,12 +12,12 @@ license = "Apache-2.0"
 include = ["src/*.rs", "Cargo.lock", "Cargo.toml", "resources/*"]
 
 [dependencies]
-clap = { version = "=4.3.24", features = ["cargo", "deprecated", "wrap_help"] }
-colour = "0.7.0"
-once_cell = "1.19.0"
+clap = { version = "=4.5.7", features = ["cargo", "wrap_help"] }
+colour = "2.1"
+once_cell = "1.19"
 
 [dev-dependencies]
-assert_cmd = "2.0.13"
-reqwest = { version = "0.11.24", features = ["blocking"] }
-serde_json = "1.0.113"
-tempfile = "3.10.0"
+assert_cmd = "2.0"
+reqwest = { version = "0.12", features = ["blocking"] }
+serde_json = "1.0"
+tempfile = "3.10"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ and run the test:
 make test
 ```
 
+### Reproducibility
+
+Currently, [cargo](https://github.com/rust-lang/cargo/issues/8140) does not provide cross-platform reproducibility for binary files, including WebAssembly. To work around the issue, we provide `rustc` wrapper, which can be enabled using `--wrapper` option.
+
+```
+cargo casper my_project --wrapper
+```
+
+
 ## License
 
 Licensed under the [Apache License Version 2.0](LICENSE).

--- a/resources/Makefile-wrapper.in
+++ b/resources/Makefile-wrapper.in
@@ -1,9 +1,14 @@
+export RUSTC_WRAPPER := $(CURDIR)/helper/wrapper
+
+helper/wrapper: helper/wrapper.rs
+	rustc --crate-name wrapper --crate-type bin -C opt-level=2 -C strip=symbols --edition=2021 -o $@ $<
+
 .PHONY: prepare build-contract test clippy check-lint lint clean
 
 prepare:
 	cd contract && rustup target add wasm32-unknown-unknown
 
-build-contract:
+build-contract: helper/wrapper
 	cd contract && cargo build --release --target wasm32-unknown-unknown
 	wasm-strip contract/target/wasm32-unknown-unknown/release/contract.wasm 2>/dev/null | true
 

--- a/resources/wrapper.rs.in
+++ b/resources/wrapper.rs.in
@@ -1,0 +1,77 @@
+use std::{
+    env,
+    io::{stderr, stdout, Write},
+    process::Command,
+};
+
+/// Change `metadata=...` argument to `metadata=file` if file is `Some`.
+/// Otherwise output plain `metadata=`. Other arguments are not modified.
+fn map_args<'a, I>(file: Option<&'a str>, args: I) -> impl Iterator<Item = String> + 'a
+where
+    I: Iterator<Item = String> + 'a,
+{
+    args.map(move |arg| {
+        let metadata = "metadata=";
+        if arg.starts_with(metadata) {
+            let mut out = metadata.to_string();
+            if let Some(path) = file {
+                out += path;
+            }
+            out
+        } else {
+            arg
+        }
+    })
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cargo_home = env::var("CARGO_HOME").expect("env variable `CARGO_HOME` must be set");
+    if !cargo_home.ends_with('/') {
+        cargo_home.push('/');
+    }
+
+    // Skip first two arguments, which is this wrapper and command name.
+    let file = env::args()
+        .skip(2)
+        .find_map(move |arg| arg.strip_prefix(&cargo_home).map(ToString::to_string));
+
+    // Skip first argument, which is this wrapper.
+    let mut args = env::args().skip(1);
+    let mut command = Command::new(args.next().unwrap());
+    command.args(map_args(
+        file.as_ref().map(|x| x.as_str()),
+        args.into_iter(),
+    ));
+    let output = command.output()?;
+    stdout().write_all(&output.stdout)?;
+    stderr().write_all(&output.stderr)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_args;
+
+    #[test]
+    fn map_rustc_args() {
+        let args = [
+            "rustc",
+            "--crate-name",
+            "counter_v2",
+            "src/main.rs",
+            "-C",
+            "metadata=aee64bf716df0053",
+            "-C",
+            "extra-filename=-aee64bf716df0053",
+        ];
+        let new_args = map_args(
+            Some("src/main.rs"),
+            args.into_iter().map(ToString::to_string),
+        );
+        assert_eq!(
+            new_args.skip(5).next(),
+            Some("metadata=src/main.rs".to_string())
+        );
+    }
+}

--- a/src/contract_package.rs
+++ b/src/contract_package.rs
@@ -21,8 +21,8 @@ static RUST_TOOLCHAIN: Lazy<PathBuf> = Lazy::new(|| CONTRACT_PACKAGE_ROOT.join("
 static CONTRACT_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(
         "{}{}",
-        CL_CONTRACT.display_with_features(true, vec![]),
-        CL_TYPES.display_with_features(true, vec![]),
+        CL_CONTRACT.display_with_features(true, &[]),
+        CL_TYPES.display_with_features(true, &[]),
     )
 });
 
@@ -33,7 +33,7 @@ target = "wasm32-unknown-unknown"
 static CARGO_TOML_CONTENTS: Lazy<String> = Lazy::new(|| {
     format!(
         r#"[package]
-name = "{}"
+name = "{PACKAGE_NAME}"
 version = "0.1.0"
 edition = "2021"
 
@@ -51,7 +51,6 @@ codegen-units = 1
 lto = true
 
 {}"#,
-        PACKAGE_NAME,
         &*CONTRACT_DEPENDENCIES,
         PACKAGE_NAME.replace('-', "_"),
         &*PATCH_SECTION
@@ -114,11 +113,9 @@ mod tests {
         {
         } else {
             println!(
-                "skipping 'check_toolchain_version_on_dev' as none of {}, {} and {} are set to {}",
-                CRON_JOB_BRANCH_NAME_ENV_VAR,
-                PR_TARGET_BRANCH_NAME_ENV_VAR,
-                CI_BRANCH_NAME_ENV_VAR,
-                TEST_BRANCH_NAME,
+                "skipping 'check_toolchain_version_on_dev' as none of \
+                {CRON_JOB_BRANCH_NAME_ENV_VAR}, {PR_TARGET_BRANCH_NAME_ENV_VAR} and \
+                {CI_BRANCH_NAME_ENV_VAR} are set to {TEST_BRANCH_NAME}",
             );
             return;
         }

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -9,6 +9,7 @@ pub struct Dependency {
 }
 
 impl Dependency {
+    #[must_use]
     pub fn new(name: &str, version: &str) -> Self {
         Dependency {
             name: name.to_string(),
@@ -16,7 +17,7 @@ impl Dependency {
         }
     }
 
-    pub fn display_with_features(&self, default_features: bool, features: Vec<&str>) -> String {
+    pub fn display_with_features(&self, default_features: bool, features: &[&str]) -> String {
         let version = if ARGS.casper_overrides().is_some() {
             "*"
         } else {
@@ -24,28 +25,30 @@ impl Dependency {
         };
 
         if default_features && features.is_empty() {
-            return format!("{} = \"{}\"\n", self.name, version);
+            return format!("{} = \"{version}\"\n", self.name);
         }
 
-        let mut output = format!(r#"{} = {{ version = "{}""#, self.name, version);
+        let mut output = format!(r#"{} = {{ version = "{version}""#, self.name);
 
         if !default_features {
-            output = format!("{}, default-features = false", output);
+            output = format!("{output}, default-features = false");
         }
 
         if !features.is_empty() {
-            output = format!("{}, features = {:?}", output, features);
+            output = format!("{output}, features = {features:?}");
         }
 
-        format!("{} }}\n", output)
+        format!("{output} }}\n")
     }
 
     #[cfg(test)]
+    #[must_use]
     pub fn name(&self) -> &str {
         &self.name
     }
 
     #[cfg(test)]
+    #[must_use]
     pub fn version(&self) -> &str {
         &self.version
     }

--- a/src/makefile.rs
+++ b/src/makefile.rs
@@ -2,7 +2,14 @@ use crate::{common, ARGS};
 
 const FILENAME: &str = "Makefile";
 const MAKEFILE_CONTENTS: &str = include_str!("../resources/Makefile.in");
+const MAKEFILE_CONTENTS_WITH_WRAPPER: &str = include_str!("../resources/Makefile-wrapper.in");
 
-pub fn create() {
-    common::write_file(ARGS.root_path().join(FILENAME), MAKEFILE_CONTENTS);
+pub fn create(use_wrapper: bool) {
+    let filename = ARGS.root_path().join(FILENAME);
+    let contents = if use_wrapper {
+        MAKEFILE_CONTENTS_WITH_WRAPPER
+    } else {
+        MAKEFILE_CONTENTS
+    };
+    common::write_file(filename, contents);
 }

--- a/src/tests_package.rs
+++ b/src/tests_package.rs
@@ -22,10 +22,10 @@ static INTEGRATION_TESTS_RS: Lazy<PathBuf> =
 pub static TEST_DEPENDENCIES: Lazy<String> = Lazy::new(|| {
     format!(
         "{}{}{}{}",
-        CL_CONTRACT.display_with_features(false, vec!["test-support"]),
-        CL_ENGINE_TEST_SUPPORT.display_with_features(true, vec!["test-support"]),
-        CL_EXECUTION_ENGINE.display_with_features(true, vec![]),
-        CL_TYPES.display_with_features(true, vec![])
+        CL_CONTRACT.display_with_features(false, &["test-support"]),
+        CL_ENGINE_TEST_SUPPORT.display_with_features(true, &["test-support"]),
+        CL_EXECUTION_ENGINE.display_with_features(true, &[]),
+        CL_TYPES.display_with_features(true, &[])
     )
 });
 

--- a/src/travis_yml.rs
+++ b/src/travis_yml.rs
@@ -1,12 +1,12 @@
 use crate::{common, ARGS};
 
 const FILENAME: &str = ".travis.yml";
-const CONTENTS: &str = r#"language: rust
+const CONTENTS: &str = r"language: rust
 script:
   - make prepare
   - make check-lint
   - make test
-"#;
+";
 
 pub fn create() {
     common::write_file(ARGS.root_path().join(FILENAME), CONTENTS);

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,0 +1,11 @@
+use crate::{common, ARGS};
+
+const FILENAME: &str = "helper/wrapper.rs";
+const WRAPPER_CONTENTS: &str = include_str!("../resources/wrapper.rs.in");
+
+pub fn create() {
+    let filename = ARGS.root_path().join(FILENAME);
+    let helper_folder = filename.parent().expect("should have parent");
+    common::create_dir_all(helper_folder);
+    common::write_file(filename, WRAPPER_CONTENTS);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -24,10 +24,10 @@ fn should_fail_when_target_path_already_exists() {
     let exit_code = output_error.as_output().unwrap().status.code().unwrap();
     assert_eq!(FAILURE_EXIT_CODE, exit_code);
 
-    let stderr: String = String::from_utf8_lossy(&output_error.as_output().unwrap().stderr).into();
+    let stderr = String::from_utf8_lossy(&output_error.as_output().unwrap().stderr);
     let expected_msg_fragment = format!(": destination '{}' already exists", test_dir.display());
-    assert!(stderr.contains(&expected_msg_fragment));
-    assert!(stderr.contains("error"));
+    assert!(stderr.contains(&expected_msg_fragment), "{}", stderr);
+    assert!(stderr.contains("error"), "{}", stderr);
 
     fs::remove_dir_all(&test_dir).unwrap();
 }
@@ -122,23 +122,22 @@ fn should_run_cargo_casper_using_published_crates() {
         Some(branch_name) if branch_name.starts_with("release-") => (),
         Some(branch_name) => {
             println!(
-                "skipping 'should_run_cargo_casper_using_published_crates' as branch name '{}' \
-                doesn't start with 'release-'",
-                branch_name
+                "skipping 'should_run_cargo_casper_using_published_crates' as branch name \
+                '{branch_name}' doesn't start with 'release-'",
             );
             return;
         }
         None => {
             println!(
-                "skipping 'should_run_cargo_casper_using_published_crates' as {} and {} are unset \
-                or set to empty strings",
-                PR_TARGET_BRANCH_NAME_ENV_VAR, CI_BRANCH_NAME_ENV_VAR
+                "skipping 'should_run_cargo_casper_using_published_crates' as \
+                {PR_TARGET_BRANCH_NAME_ENV_VAR} and {CI_BRANCH_NAME_ENV_VAR} are unset or set to \
+                empty strings",
             );
             return;
         }
     }
 
-    run_make_test_on_generated_project(None)
+    run_make_test_on_generated_project(None);
 }
 
 /// Checks that running `cargo-casper` with Git overrides yields a generated project which passes
@@ -163,9 +162,9 @@ fn should_run_cargo_casper_using_git_overrides() {
         let branch_selector = env::var(CRON_JOB_BRANCH_NAME_ENV_VAR);
         let pr_target_branch = env::var(PR_TARGET_BRANCH_NAME_ENV_VAR);
         let ci_branch = env::var(CI_BRANCH_NAME_ENV_VAR);
-        println!("{}: {:?}", CRON_JOB_BRANCH_NAME_ENV_VAR, branch_selector);
-        println!("{}: {:?}", PR_TARGET_BRANCH_NAME_ENV_VAR, pr_target_branch);
-        println!("{}: {:?}", CI_BRANCH_NAME_ENV_VAR, ci_branch);
+        println!("{CRON_JOB_BRANCH_NAME_ENV_VAR}: {branch_selector:?}");
+        println!("{PR_TARGET_BRANCH_NAME_ENV_VAR}: {pr_target_branch:?}");
+        println!("{CI_BRANCH_NAME_ENV_VAR}: {ci_branch:?}");
     }
 
     let git_branch_arg = match ci_branch_name() {
@@ -176,16 +175,16 @@ fn should_run_cargo_casper_using_git_overrides() {
             );
             return;
         }
-        Some(branch_name) => format!("--git-branch={}", branch_name),
+        Some(branch_name) => format!("--git-branch={branch_name}"),
         None => {
             println!(
-                "skipping 'should_run_cargo_casper_using_git_overrides' as {} and {} are unset or \
-                set to empty strings",
-                PR_TARGET_BRANCH_NAME_ENV_VAR, CI_BRANCH_NAME_ENV_VAR
+                "skipping 'should_run_cargo_casper_using_git_overrides' as \
+                {PR_TARGET_BRANCH_NAME_ENV_VAR} and {CI_BRANCH_NAME_ENV_VAR} are unset or set to \
+                empty strings",
             );
             return;
         }
     };
 
-    run_make_test_on_generated_project(Some(git_branch_arg))
+    run_make_test_on_generated_project(Some(git_branch_arg));
 }


### PR DESCRIPTION
* Provide rustc wrapper as an option (needed for cross-platform reproducibility and Casper Source Code Verification)
* Add .PHONY targets to Makefile
* Cleanup the code